### PR TITLE
Shellcheck of entrypoint.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
     - IMAGE_NAME_TAGGED=${DOCKERHUB_USER}/wahlzeit:${TRAVIS_TAG}
 
 script:
+  - bash -c 'shopt -s globstar nullglob; shellcheck **/*.{sh,ksh,bash}'
   - docker build -t ${IMAGE_NAME} .
 
 deploy:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 touch env-variables.txt
 
@@ -11,11 +11,14 @@ cat env-variables.txt
 touch application.properties
 echo "springfox.documentation.swagger.v2.path= /api-docs" > application.properties
 
-let line_number=0
+(( line_number=0 ))
 while read -r line; do
-    echo "app.swagger.resources[$line_number].name=$(echo $line | cut -d';' -f1)" >> application.properties
-    echo "app.swagger.resources[$line_number].location=$(echo $line | cut -d';' -f2)" >> application.properties
-    echo "app.swagger.resources[$line_number].swaggerVersion=$(echo $line | cut -d';' -f3)" >> application.properties
+    {
+        echo "app.swagger.resources[$line_number].name=$(echo "$line" | cut -d';' -f1)";
+        echo "app.swagger.resources[$line_number].location=$(echo "$line" | cut -d';' -f2)" 
+        echo "app.swagger.resources[$line_number].swaggerVersion=$(echo "$line" | cut -d';' -f3)"
+    } >> application.properties
+     
     line_number=$((line_number+1))
 done < "env-variables.txt"
 


### PR DESCRIPTION
In this MR the `entrypoint.sh` is adjusted to follow the suggestions of ShellCheck. 
Furthermore, a check of all `.sh`, `.ksh` and `.bash` files is added into the test stage of the CI. This will cause a failing pipeline if the sh/bash files doesn't follow the suggestions of ShellCheck.

You can find more information about ShellCheck under the following [link](https://github.com/koalaman/shellcheck) .